### PR TITLE
Added a binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    {
+      "target_name": "segvhandler",
+      "sources": [ "src/segvhandler.cpp"],
+    }
+
+  ]
+}


### PR DESCRIPTION
The newer way to build node addons is with node-gyp: http://nodejs.org/api/addons.html
To use this file, install the latest version of node.js and in the root of the addon do:

```
node-gyp configure
node-gyp build
```
