### PR TITLE
changes rolled up for node 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Using the module is as simple as:
 
 ```javascript
 
-var segvhandler = require('segfault-handler');
+var segvhandler = require('segvcatcher');
 
 segvhandler.registerHandler();
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,46 @@
+{
+  "targets": [
+    {
+      "target_name": "segvhandler",
+      'include_dirs': [
+      ],
+      'conditions': [
+        ['OS=="mac"', {
+          'cflags_cc': [
+            "-Wall",
+            "-Werror",
+            '-DDEBUG',
+            '-O0',
+            '-mmacosx-version-min=10.4'
+          ],
+          'link_settings': {
+            'ldflags': [
+              '-mmacosx-version-min=10.4'
+            ]
+          }
+        }],
+        ['OS!="mac"', {
+          'cflags_cc': [
+            "-Wall",
+            '-DDEBUG',
+            '-O0'
+          ],
+          'link_settings': {
+            'ldflags': [
+            ]
+          }
+        }]
+      ],
+      'cflags!': [
+        '-fno-exceptions'
+      ],
+      'cflags_cc!': [
+        '-fno-exceptions'
+      ],
+      "sources": [ 
+        "src/segvhandler.cpp"
+      ]
+    }
+  ]
+}
+ 

--- a/lib/segvhandler.js
+++ b/lib/segvhandler.js
@@ -1,8 +1,1 @@
-try {
-  // as of node 0.6.x, node-waf seems to build to a different directory. grr.
-  var native = require(__dirname + '/../build/Release/segvhandler_native');
-} catch(e) {
-  var native = require(__dirname + '/../build/default/segvhandler_native');
-}
-
-module.exports = native;
+module.exports = require('bindings')('segvhandler');

--- a/package.json
+++ b/package.json
@@ -12,12 +12,8 @@
   }
   ,"devDependencies": {
   }
-  ,"main": "lib/segvcatcher.js"
+  ,"main": "lib/segvhandler.js"
   ,"directories": {
     "bin": "./bin"
-  }
-  ,"scripts": {
-    "build" : "node-waf configure build"
-    ,"test" : "vows --spec test/*-test.js"
   }
 }

--- a/src/segvhandler.cpp
+++ b/src/segvhandler.cpp
@@ -75,7 +75,10 @@ Handle<Value> RegisterHandler(const Arguments& args) {
   return Undefined();
 }
 
-extern "C" void init(Handle<Object> target) {
-  NODE_SET_METHOD(target, "registerHandler", RegisterHandler);
-  NODE_SET_METHOD(target, "causeSegfault", CauseSegfault);
+extern "C" {
+  void init(Handle<Object> target) {
+    NODE_SET_METHOD(target, "registerHandler", RegisterHandler);
+    NODE_SET_METHOD(target, "causeSegfault", CauseSegfault);
+  }  
+  NODE_MODULE(segvhandler, init); 
 }


### PR DESCRIPTION
Took a couple of the other pull requests, and fleshed them out.  Add compile options for the Mac, but they are untested.  This set was tested on a CentOS 5.1 32-bit machine.

Updated the Readme, as well :-)

I am using this to try and debug a long-running process that uses node-db-mysql and node-genx.  One of them appears to be segfaulting under 0.10.0, and I am hoping this helps me find out which.