### PR TITLE
Make module to load also in Node 0.10.x

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   "targets": [
     {
-      "target_name": "segfault-handler-native",
+      "target_name": "segfault_handler",
       "sources": [
         "src/segfault-handler.cpp"
       ],

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 
 // The 'bindings' helper will try all the well-known paths that the module might compile to based on platform / version / debug / etc
-module.exports = require('bindings')('segfault-handler-native');
+module.exports = require('bindings')('segfault_handler');
 


### PR DESCRIPTION
Make module load also under Node 0.10.x by using same module name throughout src/segfault-handler.cpp, binding.gyp, and index.js .

See also my comments at
 https://github.com/ddopson/node-segfault-handler/pull/4
