### PR TITLE
Implemented Nan and aligned to segfault_handler naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Using the module is as simple as:
 
 ```javascript
 
-var SegfaultHandler = require('segfault-handler');
+var SegfaultHandler = require('segfault_handler');
 
 SegfaultHandler.registerHandler();
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,7 +9,10 @@
       "cflags": [ "-O0" ],
       "xcode_settings": {
         "OTHER_CFLAGS": [ "-O0" ]
-      }
+      },
+      "include_dirs": [
+               "<!(node -e \"require('nan')\")"                          
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
-  "name": "segfault-handler"
-  ,"description": "catches SIGSEGV and prints diagnostic information"
-  ,"version": "0.2.1"
-  ,"author": "Dave Dopson <ddopson@gmail.com>"
-  ,"contributors": [
-     "Dave Dopson <ddopson@gmail.com>"
-    ,"Mark Smith <msmith@rallydev.com>"
-    ,"David Swift <dswift@pccowboy.com>"
-  ]
-  ,"dependencies": {
-    "bindings": "*"
-  }
-  ,"main": "index.js"
+  "name": "segfault_handler",
+  "description": "catches SIGSEGV and prints diagnostic information",
+  "version": "0.2.1",
+  "author": "Dave Dopson <ddopson@gmail.com>",
+  "contributors": [
+    "Dave Dopson <ddopson@gmail.com>",
+    "Mark Smith <msmith@rallydev.com>",
+    "David Swift <dswift@pccowboy.com>",
+    "Anton Whalley <anton@venshare.com>"
+  ],
+  "dependencies": {
+    "bindings": "^1.2.1",
+    "nan": "^1.3.0"
+  },
+  "main": "index.js"
 }

--- a/src/segfault-handler.cpp
+++ b/src/segfault-handler.cpp
@@ -13,6 +13,8 @@
 #include <node_buffer.h>
 #include <node_object_wrap.h>
 #include <v8-debug.h>
+#include <nan.h>
+
 using namespace v8;
 using namespace node;
 
@@ -72,21 +74,23 @@ void segfault_stack_frame_2(void) {
   fn_ptr();
 }
 
-Handle<Value> CauseSegfault(const Arguments& args) {
+NAN_METHOD(CauseSegfault) {
+  NanScope();
   // use a function pointer to thwart inlining
   void (*fn_ptr)() = segfault_stack_frame_2;
   fn_ptr();
-  return Undefined();  // this line never runs
+  NanReturnUndefined();  // this line never runs
 }
 
-Handle<Value> RegisterHandler(const Arguments& args) {
+NAN_METHOD(RegisterHandler) {
+  NanScope();
   struct sigaction sa;
   memset(&sa, 0, sizeof(struct sigaction));
   sigemptyset(&sa.sa_mask);
   sa.sa_sigaction = segfault_handler;
   sa.sa_flags   = SA_SIGINFO;
   sigaction(SIGSEGV, &sa, NULL);
-  return Undefined();
+  NanReturnUndefined();
 }
 
 extern "C" {


### PR DESCRIPTION
This is a breaking change as it names the module segfault_handler with an underscore to make the build and sample code work. 
On the upside it implements Nan change and so should run on later version of node. 
Would recommend publishing in npm as segfault_handler too for consistency and maybe removing/deprecating the current 2.1 in there. 
