### PR TITLE
Only use nan 1.3.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^1.3.0"
+    "nan": "~1.3.0"
   },
   "main": "index.js"
 }


### PR DESCRIPTION
nan 1.4.0 was recently released, but is not compatible with
this package. Only allow patch level updates until the compatibility
issue is worked out.
