### PR TITLE
Fix a typo in the name of the node module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Using the module is as simple as:
 
 ```javascript
 
-var SegfaultHandler = require('segfault_handler');
+var SegfaultHandler = require('segfault-handler');
 
 SegfaultHandler.registerHandler();
 


### PR DESCRIPTION
The example code calls module named "segfault_handler", while the name of the module is "segfault**-**handler"