### PR TITLE
Initial support for javascript callbacks for node >= 0.12 running on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ var SegfaultHandler = require('segfault-handler');
 
 SegfaultHandler.registerHandler("crash.log"); // With no argument, SegfaultHandler will generate a generic log file name
 
+// Optionally specify a callback function for custom logging. This feature is currently only supported for Node.js >= v0.12 running on Linux.
+SegfaultHandler.registerHandler("crash.log", function(signal, address, stack) {
+	// Do what you want with the signal, address, or stack (array)
+	// This callback will execute before the signal is forwarded on.
+});
+
 SegfaultHandler.causeSegfault(); // simulates a buggy native module that dereferences NULL
 
 ```


### PR DESCRIPTION
Inspired by https://github.com/ddopson/node-segfault-handler/pull/11 and updated to support newer versions of Node.js as well as proper handling of cross-thread callbacks.

I haven't had the time to look into what it would take to get it fully implemented for Windows, it would need a dependency or alternative for pthreads and a way to get the stack array from StackWalker.

Regardless, it should still build and run the same as always on Windows, just without callback support.