### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
     "bindings": "^1.2.1",
     "nan": "^2.0.9"
   },
-  "main": "index.js"
+  "main": "index.js",
+  "license": "SEE LICENSE IN README.md"
 }


### PR DESCRIPTION
Cuz npm install is complaining and I don't like rubbish in my logs:
```
npm info package.json segfault-handler@1.0.0 No license field.
```

https://docs.npmjs.com/files/package.json#license

Cheers!