### PR TITLE
Fix lack of stack trace on ARM

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,9 +18,9 @@
           ]
         }]
       ],
-      "cflags": [ "-O0" ],
+      "cflags": [ "-O0", "-funwind-tables" ],
       "xcode_settings": {
-        "OTHER_CFLAGS": [ "-O0" ]
+        "OTHER_CFLAGS": [ "-O0", "-funwind-tables" ]
       },
       "include_dirs": [
         "<!(node -e \"require('nan')\")"


### PR DESCRIPTION
On ARM, the default installation of this module would produce no stack trace. Example:

`root@beaglebone:~/test/node_modules/segfault-handler# node example.js 
NodeSegfaultHandlerNative: about to dereference NULL (will cause a SIGSEGV)
PID 1907 received SIGSEGV for address: 0x2
root@beaglebone:~/test/node_modules/segfault-handler# uname -a
Linux beaglebone 4.1.19-bone-rt-r20 #1 Sun Mar 13 04:30:34 UTC 2016 armv7l GNU/Linux`

The fix is to build with `-funwind-tables` as per http://stackoverflow.com/questions/24700150/on-raspberry-pi-backtrace-returns-0-frames:

`root@beaglebone:~/test/node_modules/segfault-handler# node example.js 
NodeSegfaultHandlerNative: about to dereference NULL (will cause a SIGSEGV)
PID 2268 received SIGSEGV for address: 0x2
/root/test/node_modules/segfault-handler/build/Release/segfault-handler.node(+0x12a0)[0xb68ba2a0]
/lib/arm-linux-gnueabihf/libc.so.6(+0x26b00)[0xb68f1b00]
/root/test/node_modules/segfault-handler/build/Release/segfault-handler.node(_Z22segfault_stack_frame_1v+0x1f)[0xb68ba5c4]
/root/test/node_modules/segfault-handler/build/Release/segfault-handler.node(+0x1434)[0xb68ba434]`

Works on at least ARM and OS X. See also #24.
