### PR TITLE
backport to node0.10 by using more of Nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^2.13.2"
+    "nan": "^2.14.0"
   },
   "main": "index.js",
   "license": "BSD-3-Clause"


### PR DESCRIPTION
Node 0.10 support appears to be dropped after v1.0.0 despite this module using nan. I'm trying to upgrade a codebase that's currently running on 0.10 but I need this module to work on both targets. This is my attempt at using nan almost exclusively where possible. Hopefully this will aid with adding support for future versions too. Note also that the callback signature in libuv is different between 0.x and 1.x, hence the version checks.