### PR TITLE
support alpine

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  "variables": {
+    "BUILD_WITH_LIBEXEC": "<!(python -c 'from ctypes.util import find_library;print int(find_library(\"execinfo\")!=None)')",
+  },
   "targets": [
     {
       "target_name": "segfault-handler",
@@ -6,6 +9,11 @@
         "src/segfault-handler.cpp"
       ],
       "conditions": [
+        [ "<(BUILD_WITH_LIBEXEC)==1", {
+          "libraries": [
+            "-lexecinfo"
+          ]
+        }],
         ["OS=='win'", {
           "msvs_settings": {
             "VCCLCompilerTool": {


### PR DESCRIPTION
Alpine image uses Musl not the GNULIB, and musl doesn't include the backtrace function but is available through the library libexecinfo.
When installing this lib on Alpine environment, the building works but it crashes at runtime with
```
Error: Error relocating node_modules/segfault-handler/build/Release/segfault-handler.node: backtrace: symbol not found
```

To fix this, this PR allow node-gyp to build the module against libexecinfo when available.