### PR TITLE
Turn off nan Related Warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,6 +24,11 @@
             "src/StackWalker.cpp",
             "includes/StackWalker.h"
           ]
+        }],
+        ["OS == 'linux'", {
+          "cflags_cc": [
+            "-Wno-cast-function-type" # nan issue: https://github.com/nodejs/nan/issues/807
+          ]
         }]
       ],
       "cflags": [ "-O0", "-funwind-tables" ],


### PR DESCRIPTION
On Alpine Linux (popular in docker containers) building this project spews a bunch of warnings that, while not dire, make things hard to debug and scare people who might know how to NodeJS but not know how to native module in NodeJS.

	make: Entering directory '/project/build'
	  CXX(target) Release/obj.target/segfault-handler/src/segfault-handler.o
	In file included from ../src/segfault-handler.cpp:2:
	../node_modules/nan/nan.h: In function 'void Nan::AsyncQueueWorker(Nan::AsyncWorker*)':
	../node_modules/nan/nan.h:2298:62: warning: cast between incompatible function types from 'void (*)(uv_work_t*)' {aka 'void (*)(uv_work_s*)'} to 'uv_after_work_cb' {aka 'void (*)(uv_work_s*, int)'} [-Wcast-function-type]
	 2298 |     , reinterpret_cast<uv_after_work_cb>(AsyncExecuteComplete)
		  |                                                              ^
	In file included from ../node_modules/nan/nan.h:54,
					 from ../src/segfault-handler.cpp:2:
	../src/segfault-handler.cpp: At global scope:
	/root/.cache/node-gyp/14.8.0/include/node/node.h:746:43: warning: cast between incompatible function types from 'void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)' {aka 'void (*)(v8::Local<v8::Object>)'} to 'node::addon_register_func' {aka 'void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)'} [-Wcast-function-type]
	  746 |       (node::addon_register_func) (regfunc),                          \
		  |                                           ^
	/root/.cache/node-gyp/14.8.0/include/node/node.h:780:3: note: in expansion of macro 'NODE_MODULE_X'
	  780 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
		  |   ^~~~~~~~~~~~~
	../src/segfault-handler.cpp:346:3: note: in expansion of macro 'NODE_MODULE'
	  346 |   NODE_MODULE(segfault_handler, init)
		  |   ^~~~~~~~~~~
	  SOLINK_MODULE(target) Release/obj.target/segfault-handler.node
	  COPY Release/segfault-handler.node
	make: Leaving directory '/project/build'

This PR adds a `-Wno-cast-function-type` compiler flag to allow for a less noisy/scary build in alpine environments and fewer people coming at us thinking these warnings are problems.
