### PR TITLE
Pass debug messages on to someone else to handle - Windows specific

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "BUILD_WITH_LIBEXEC": "<!(python -c 'from ctypes.util import find_library;print int(find_library(\"execinfo\")!=None)')",
+    "BUILD_WITH_LIBEXEC": "<!(python -c \"from ctypes.util import find_library;print(int(find_library('execinfo')!=None))\")",
   },
   "targets": [
     {


### PR DESCRIPTION
Some Windows libraries use [OutputDebugString()](https://docs.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-outputdebugstringa?redirectedfrom=MSDN) to log a message to a debugger. This works by throwing an exception and then a debugger being a registered exception handler. For example, th Google family of chromium-based APIs do this, including libwebrtc that is part of node-webrtc.

Unfortunately, node-segfault-handler intercepts these exceptions and reports them as SIGSEGV, printing a stack trace and marks them as handled by returning EXCEPTION_EXECUTE_HANDLER. In this case and implemented by this PR, it would be better to not handle the exception and pass it onto any other interested party with EXCEPTION_CONTINUE_SEARCH.

Also, as part of the debugging process, the code can [try to set the thread name](https://docs.microsoft.com/en-us/visualstudio/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2019) via exception. This PR also passes this exception onwards and upwards.