### PR TITLE
change windows behavior to not fire on handled exs

### DIFF
--- a/src/segfault-handler.cpp
+++ b/src/segfault-handler.cpp
@@ -326,7 +326,7 @@ NAN_METHOD(RegisterHandler) {
   }
 
   #ifdef _WIN32
-    AddVectoredExceptionHandler(1, segfault_handler);
+    SetUnhandledExceptionFilter(segfault_handler);
   #else
     struct sigaction sa;
     memset(&sa, 0, sizeof(struct sigaction));


### PR DESCRIPTION
As was pointed out [here](https://github.com/ddopson/node-segfault-handler/issues/46#issue-239671538), handled exceptions are reported by `segfault-handler` before reaching their catch blocks. This change will make it so that handled exceptions pass silently.