### PR TITLE
fix: return type of CrashCallback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export type SIGNAL = "SIGSEGV" | string;
 
-export type CrashCallback = (signal: SIGNAL, address: string, stack: string[]) => any;
+export type CrashCallback = (signal: SIGNAL, address: string, stack: string[]) => void;
 
 export function registerHandler(): void;
 export function registerHandler(file: string): void;


### PR DESCRIPTION
The crash callback doesn't do anything with the returned value so this should be `void` to indicate that.